### PR TITLE
feat: forward parent lifecycles to child stages defined on the module

### DIFF
--- a/examples/module-phases-inheritance/calculator/togomak.hcl
+++ b/examples/module-phases-inheritance/calculator/togomak.hcl
@@ -1,0 +1,30 @@
+togomak {
+  version = 2
+}
+
+variable "a" {
+  type = number
+  description = "first variable"
+}
+variable "b" {
+  type = number 
+  description = "second variable"
+}
+
+variable "operation" {
+  type = string 
+  description = "Operation to perform, any of: [add, subtract, multiply, divide]"
+}
+
+stage "add" {
+  if = var.operation == "add"
+  script = "echo ${var.a} + ${var.b} is ${var.a + var.b}"
+}
+
+stage "paths" {
+  script = <<-EOT
+  echo path.module: ${path.module}
+  echo path.cwd: ${path.cwd}
+  echo path.root: ${path.root}
+  EOT
+}

--- a/examples/module-phases-inheritance/togomak.hcl
+++ b/examples/module-phases-inheritance/togomak.hcl
@@ -1,0 +1,28 @@
+ togomak {
+  version = 2
+}
+
+locals {
+  a = 99
+  b = 1
+}
+
+stage "paths" {
+  script = <<-EOT
+  echo path.module: ${path.module}
+  echo path.cwd: ${path.cwd}
+  echo path.root: ${path.root}
+  EOT
+}
+
+module "add" {
+  source = "./calculator"
+  a = local.a
+  b = local.b
+  operation = "add"
+
+  lifecycle {
+    phase = ["add"]
+  }
+}
+

--- a/internal/behavior/models.go
+++ b/internal/behavior/models.go
@@ -7,6 +7,8 @@ type Child struct {
 	// Parent is the flag to indicate whether the program is running in parent mode
 	Parent string
 
+	ParentLifecycles []string
+
 	// ParentParams is the list of parameters to be passed to the parent
 	ParentParams []string
 }

--- a/tests/togomak.hcl
+++ b/tests/togomak.hcl
@@ -49,6 +49,36 @@ stage "tests" {
   }
 }
 
+stage "module_phase_test" {
+  pre_hook {
+    stage {
+      script = "echo ${ansi.fg.green}${each.key}${ansi.reset}: full"
+    }
+  }
+
+  for_each = toset([
+    "../examples/module-phases-inheritance/togomak.hcl",
+  ])
+
+  depends_on = [stage.build, stage.coverage_prepare]
+  args = [
+    "./togomak_coverage",
+    "-C", dirname(each.key),
+    "--ci", "-v", "-v", "-v",
+    "add"
+  ]
+
+  env {
+    name  = "GOCOVERDIR"
+    value = local.coverage_data_dir
+  }
+  env {
+    name  = "TOGOMAK_VAR_name"
+    value = "bot"
+  }
+
+}
+
 
 stage "tests_dry_run" {
   pre_hook {
@@ -82,7 +112,7 @@ stage "fmt" {
 }
 
 stage "cache" {
-  depends_on = [stage.fmt, stage.tests, stage.tests_dry_run]
+  depends_on = [stage.fmt, stage.tests, stage.tests_dry_run, stage.module_phase_test]
   script     = "./togomak_coverage cache clean --recursive"
 }
 


### PR DESCRIPTION
In scenarios where lifecycles are defined on the module level, there was an issue preventing the same lifecycle phases from being applied to the child modules. This was very inconvenient when reusing multiple modules and the caller may have custom lifecycle phases, but the module's are not owned by the caller to make changes